### PR TITLE
Correct the spelling of CocoaPods in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 > Node.js inspired EventEmitter for Objective C.
 
 [![Build Status](https://travis-ci.org/jerolimov/EventEmitter.svg)](https://travis-ci.org/jerolimov/EventEmitter)
-[![Cocoapods Compatible](https://img.shields.io/cocoapods/v/EventEmitter.svg)](https://cocoapods.org/pods/EventEmitter)
+[![CocoaPods Compatible](https://img.shields.io/cocoapods/v/EventEmitter.svg)](https://cocoapods.org/pods/EventEmitter)
 [![Supported Platforms](https://img.shields.io/cocoapods/p/EventEmitter.svg?style=flat)](http://cocoadocs.org/docsets/EventEmitter)
 
 ## How to use it


### PR DESCRIPTION
This pull requests corrects the spelling of **CocoaPods** 🤓
https://github.com/CocoaPods/shared_resources/tree/master/media

<blockquote class="twitter-tweet" data-lang="en"><p lang="en" dir="ltr">One day I’ll make a bot that looks through the READMEs of all Pods, looks to see if it uses “Cocoapods” and PRs “CocoaPods” :D</p>&mdash; Ørta (@orta) <a href="https://twitter.com/orta/status/697374357975388160">February 10, 2016</a></blockquote>

<script async src="//platform.twitter.com/widgets.js" charset="utf-8"></script>
